### PR TITLE
Deployment script fixes

### DIFF
--- a/_src/scripts/deploy-site.sh
+++ b/_src/scripts/deploy-site.sh
@@ -25,11 +25,11 @@ jekyll clean && \
     cp -r html/* tmp_site/ && \
     ln -s /home/ryan/irclogs/freenode/mlpack/ tmp_site/irc/logs && \
     ln -s /home/jenkins-mlpack/workspace/blog/script/blog/doxygen tmp_site/gsocblog && \
-    mkdir old_site/ && \
-    mv "$1/"* old_site/ && \
+    mkdir _old_site/ && \
+    mv "$1/"* _old_site/ && \
     mv tmp_site/* "$1/" && \
     ln -s "$1/doc/$newest_version" "$1/doc/stable" && \
-    rm -rf tmp_site old_site;
+    rm -rf tmp_site _old_site;
 
 # Allow others in the www-mlpack group to modify the site.
 chgrp -R www-mlpack $1/

--- a/_src/scripts/deploy-site.sh
+++ b/_src/scripts/deploy-site.sh
@@ -30,3 +30,7 @@ jekyll clean && \
     mv tmp_site/* "$1/" && \
     ln -s "$1/doc/$newest_version" "$1/doc/stable" && \
     rm -rf tmp_site old_site;
+
+# Allow others in the www-mlpack group to modify the site.
+chgrp -R www-mlpack $1/
+chmod -R g+w $1/


### PR DESCRIPTION
This fixes a couple issues encountered when the website was automatically rebuilt:

1. Change the group of all deployed files to `www-mlpack` so anyone with an account on mlpack.org can modify them if needed.
2. Use a directory called `_old_site` to temporarily store the old site, so that if the build failed earlier, Jekyll won't try to build everything in `old_site` too.