### PR TITLE
Update dataset download URL to zenodo.

### DIFF
--- a/_src/scripts/deploy-site.sh
+++ b/_src/scripts/deploy-site.sh
@@ -15,7 +15,7 @@ newest_version=`ls doc/ | grep 'mlpack-[0-9]' | sort -r | head -1`;
 rm -rf datasets/;
 mkdir datasets/;
 cd datasets/;
-wget https://www.ratml.org/misc/datasets.tar.gz;
+wget https://zenodo.org/record/4042173/files/datasets.tar.gz;
 tar -xvzpf datasets.tar.gz;
 rm datasets.tar.gz;
 cd ../


### PR DESCRIPTION
I uploaded `datasets.tar.gz` to Zenodo like @bkmgit suggested in https://github.com/mlpack/examples/issues/28.

https://zenodo.org/record/4042173

This should make it easier for people to modify the datasets.  I don't (yet) know how to give Zenodo access to that file to every contributor to mlpack, but perhaps we can figure out that part later.

This change to the website script simply grabs the Zenodo dataset URL instead of grabbing it from my personal website.