### PR TITLE
Do not set the maximum number of editor lines, to avoid editor height issue.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -375,7 +375,6 @@ editor.getSession().setMode("ace/mode/javascript");
 editor.setTheme("ace/theme/monokai");
 editor.getSession().setMode("ace/mode/c_cpp");
 editor.setPrintMarginColumn(false);
-editor.setOption("maxLines", 23);
 editor.setValue(cppCode, -1);
 
 function changeLang(id)


### PR DESCRIPTION
As pointed out by @rcurtin the height of the editor doesn't match with the window height, this fix should resolve the issue.