### PR TITLE
Link to the latest stable version.

### DIFF
--- a/html/community.html
+++ b/html/community.html
@@ -67,7 +67,7 @@
 		 community. Since mlpack is an open-source project, anyone is welcome to
 		 become a part of the community and contribute. There is no need to be a
 		 machine learning expert to participate—often, there are many tasks to be done
-		 that don’t require in-depth knowledge.
+		 that don't require in-depth knowledge.
 		</p>
 
 		<p align="justify">
@@ -81,27 +81,27 @@
 
 		<h3 id="page-involved">Getting Involved</h3>
 		<p align="justif">
-			Everyone is welcome to contribute to mlpack. But before becoming a contributor, it’s often useful to understand
+			Everyone is welcome to contribute to mlpack. But before becoming a contributor, it's often useful to understand
 			mlpack as a user. So, a good place to start is to <a href="https://www.mlpack.org/index.html">download mlpack</a>
-			and use the <a href="https://www.mlpack.org/doc/mlpack-3.1.0/python_documentation.html">Python bindings</a>,
-			<a href="https://www.mlpack.org/doc/mlpack-3.1.0/julia_documentation.html">Julia bindings</a> or the
-			<a href="https://www.mlpack.org/doc/mlpack-3.1.0/cli_documentation.html">command-line
+			and use the <a href="https://www.mlpack.org/doc/stable/python_documentation.html">Python bindings</a>,
+			<a href="https://www.mlpack.org/doc/stable/julia_documentation.html">Julia bindings</a> or the
+			<a href="https://www.mlpack.org/doc/stable/cli_documentation.html">command-line
 			programs</a> to perform machine learning tasks. You can also write C++ programs to perform machine learning tasks with
-			mlpack; <a href="https://www.mlpack.org/doc/mlpack-3.1.0/doxygen/sample.html">here</a> are some basic examples.
+			mlpack; <a href="https://www.mlpack.org/doc/stable/doxygen/sample.html">here</a> are some basic examples.
 		</p>
 
 		<p align="justif">
-			Once you have an idea of what’s included in mlpack and how a user might use it, then a good next step would be to
+			Once you have an idea of what's included in mlpack and how a user might use it, then a good next step would be to
 			set up a development environment. Once you have that set up, you can
-			<a href="https://www.mlpack.org/doc/mlpack-3.1.0/doxygen/build.html">build mlpack from source</a>
+			<a href="https://www.mlpack.org/doc/stable/doxygen/build.html">build mlpack from source</a>
 			and <a href="https://github.com/mlpack/mlpack/">explore the
-			codebase</a> to see how it’s organized. It may even be useful to try and make
+			codebase</a> to see how it's organized. It may even be useful to try and make
 			small changes to the code, then rebuild the command-line programs and see
 			what your changes did.
 		</p>
 
 		<p align="justif">
-			Now you’re set up to contribute! There are lots of ways you can contribute. Here are a couple ideas:
+			Now you're set up to contribute! There are lots of ways you can contribute. Here are a couple ideas:
 		</p>
 
 		<p align="justif" style="padding-left:10px;">
@@ -125,19 +125,20 @@
 			<span style="color:#D0331F">&bull;</span> Find an abandoned pull request;
 			 <a href="https://github.com/mlpack/mlpack/pulls?q=is%3Aclosed+is%3Apr+label%3A%22s%3A+stale%22">here</a>
 			  is a list of pull requests that
-			were closed for inactivity. Often these have comments that need to be addressed, but the original author didn’t
+			were closed for inactivity. Often these have comments that need to be addressed, but the original author
+			didn't
 			have time to finish the work. So, you can pick up where they left off!
 		</p>
 
 		<p align="justif" style="padding-left:10px;">
-			<span style="color:#D0331F">&bull;</span> Implement a new machine learning algorithm that mlpack doesn’t currently
+			<span style="color:#D0331F">&bull;</span> Implement a new machine learning algorithm that mlpack doesn't currently
 			have.
 		</p>
 
 		<p align="justif" style="padding-left:10px;">
 			<span style="color:#D0331F">&bull;</span> Take a look at the ideas on the Google Summer of Code <a
 			href="https://github.com/mlpack/mlpack/wiki/SummerOfCodeIdeas">Ideas List</a> and see
-			if you find any of them interesting or exciting. Even if you’re not planning to do Summer of Code, it’s okay to
+			if you find any of them interesting or exciting. Even if you're not planning to do Summer of Code, it's okay to
 			take these ideas and implement them separately.
 		</p>
 
@@ -218,7 +219,7 @@ emails for all mlpack-related activity: <a href="https://lists.mlpack.org/mailma
 				<br><br>
 				<img src="static/img/slack-logo.svg" width="50" alt="slack logo">
 				<p style="text-align:justify">
-					<a href="https://mlpack.slack.org/">mlpack.slack.org</a>; in order to create an account, you’ll need to use the auto-inviter to send yourself an invite: <a href="http://slack-inviter.mlpack.org:3000/">slack-inviter.mlpack.org</a>.
+					<a href="https://mlpack.slack.org/">mlpack.slack.org</a>; in order to create an account, you'll need to use the auto-inviter to send yourself an invite: <a href="http://slack-inviter.mlpack.org:3000/">slack-inviter.mlpack.org</a>.
 				</p>
 			</div>
 


### PR DESCRIPTION
AS pointed out in IRC by RishabhGarg108, the community page doesn't link to the latest version. Instead of specifying the latest version, I figured it would be easier to just use the stable alias.