### PR TITLE
Strip language names only where needed

### DIFF
--- a/_src/scripts/rebuild-docs.sh
+++ b/_src/scripts/rebuild-docs.sh
@@ -76,7 +76,8 @@ do
              '"$awk_filter"'
              // { if(no_print != 1) { print $0; } }' |\
         sed 's/<div .*//' |\
-        sed 's/'"$l"'_//' > doc/mlpack-${version}/${l}_binding_documentation_mod.md;
+        sed 's/#'"$l"'_//' |\
+        sed 's/#doc_'"$l"'_//' > doc/mlpack-${version}/${l}_binding_documentation_mod.md;
     eval ${grep_filter} | sed 's/#'"$l"'_/#/' >\
         doc/mlpack-${version}/${l}_binding_header_mod.md;
 


### PR DESCRIPTION
This comes out of https://github.com/mlpack/mlpack/pull/2661.

I found that on the website, the `bayesian_linear_regression` R binding is actually just called `bayesian_linearegression`, which is amusing but not correct. :smile:

https://www.mlpack.org/doc/mlpack-git/r_documentation.html#example-2

The reason for this appears to be a regex that, during processing of the generated Markdown bindings, strips `$lang_` throughout.  If `$lang` is `r`, this causes `bayesian_linear_regression` to become `bayesian_linearegression`.  So, I looked through `mlpack.md` and found that for other bindings, the only things that get stripped are anchor refs of the form

 - `#$lang_`
 - `#doc_$lang_`

e.g. `#go_` or `#doc_go_`.

So, this PR simply updates that regex to be more specific and only catch those two cases.