### PR TITLE
https (lab.mlpack.org) + temporarily removed benchmark link

### DIFF
--- a/html/getstarted.html
+++ b/html/getstarted.html
@@ -93,7 +93,7 @@
 	<div></div>
 
 	<div style="width:200px;height:40px;border-radius:5px;background-color:#BABFC6">
-		<div style="padding-top:10px"><a style="text-decoration:none;color:black" href="http://lab.mlpack.org/v2/gh/mlpack/examples/master?urlpath=lab">Jupyter cloud</a></div>
+		<div style="padding-top:10px"><a style="text-decoration:none;color:black" href="https://lab.mlpack.org/v2/gh/mlpack/examples/master?urlpath=lab">Jupyter cloud</a></div>
 	</div>
 
 	<div style="width:200px;height:40px;border-radius:5px;background-color:#BABFC6">

--- a/html/index.html
+++ b/html/index.html
@@ -315,7 +315,7 @@
 		</center>
 
 		<p>
-			Several randomly generated, uniformly distributed datasets of varying sizes were used for this benchmark. The computation time of k-NN with k=5 for each library and each dataset size is given in Table. <a href="">Read more &rarr;</a>.
+			Several randomly generated, uniformly distributed datasets of varying sizes were used for this benchmark. The computation time of k-NN with k=5 for each library and each dataset size is given in Table.
 		</p>
 	</div>
 	<!-- BENCHMARK END -->


### PR DESCRIPTION
- The webserver doesn't automatically redirect from http to https, so use https://lab.mlpack.org as default.
- Temporarily remove the benchmark details page, until it's ready, to avoid confusion.