### PR TITLE
change the url for covertype dataset in the python code at the home page

### DIFF
--- a/html/static/js/code.js
+++ b/html/static/js/code.js
@@ -63,7 +63,7 @@ pythonCode +=
   '# Load the dataset from an online URL.  Replace with "covertype.csv.gz" if you\r\n';
 pythonCode += "# want to use on the full dataset.\r\n";
 pythonCode +=
-  'df = pd.read_csv("https://lab.mlpack.org/data/covertype-small.csv.gz")\r\n\r\n';
+  'df = pd.read_csv("https://www.mlpack.org/datasets/covertype-small.csv.gz")\r\n\r\n';
 pythonCode += "# Split the labels.\r\n";
 pythonCode += 'labels = df["label"]\r\n';
 pythonCode += 'dataset = df.drop("label", 1)\r\n\r\n';


### PR DESCRIPTION
the original url is now responsing 404 not found.
I do not know how did the server "cache" the stdout of these unmodified codes. Some extra changes might be required if the caching algoritm is not perfect enough.
