### PR TITLE
Remove the step where we download datasets

### DIFF
--- a/_src/scripts/build-website-from-scratch.sh
+++ b/_src/scripts/build-website-from-scratch.sh
@@ -7,15 +7,6 @@
 # - make sure all .tar.gzs are dropped in files/.
 # - run this script with $PWD=root of repository
 
-# Download datasets.
-rm -rf datasets/;
-mkdir datasets/;
-cd datasets/;
-wget https://www.ratml.org/misc/datasets.tar.gz;
-tar -xvzpf datasets.tar.gz;
-rm datasets.tar.gz;
-cd ../
-
 # We need a working copy of the site.
 jekyll b;
 

--- a/_src/scripts/deploy-site.sh
+++ b/_src/scripts/deploy-site.sh
@@ -11,19 +11,6 @@ fi
 # Find the newest version.
 newest_version=`ls doc/ | grep 'mlpack-[0-9]' | sort -r | head -1`;
 
-# Download datasets.
-rm -rf datasets/;
-mkdir datasets/;
-cd datasets/;
-# Reproducible source is at:
-# https://zenodo.org/record/5021503/files/datasets.tar.gz;
-# We use the local mirror instead to avoid triggering 429s from Zenodo (and also
-# to reduce bandwidth usage).
-wget https://ratml.org/misc/datasets.tar.gz
-tar -xvzpf datasets.tar.gz;
-rm datasets.tar.gz;
-cd ../
-
 jekyll clean && \
     jekyll b -d tmp_site/ -b / && \
     cp -r html/* tmp_site/ && \


### PR DESCRIPTION
This goes with mlpack/examples#163 and shouldn't be merged before that one.  The PR simply removes the `datasets/` subdirectory from the website; instead, datasets can now be hosted much more easily on `https://datasets.mlpack.org/`.