### PR TITLE
Download dependencies during documentation builds

### DIFF
--- a/_src/scripts/build-version.sh
+++ b/_src/scripts/build-version.sh
@@ -60,7 +60,7 @@ echo "Generating documentation for version $version...";
 cd _src/mlpack-$version/;
 mkdir -p build/;
 cd build/;
-cmake -DBUILD_MARKDOWN_BINDINGS=ON ../;
+cmake -DDOWNLOAD_DEPENDENCIES=ON -DBUILD_MARKDOWN_BINDINGS=ON ../;
 make -j4 markdown;
 if [ "$?" -ne "0" ];
 then


### PR DESCRIPTION
Some of the build nodes on ci.mlpack.org don't have a new enough version of Armadillo available in their package managers.  I figured, the easiest solution is to simply use the autodownloader. :)

This should fix the currently-failing nightly doxygen build that gets deployed to mlpack.org.