### PR TITLE
Fixed the title of docs.html

### DIFF
--- a/html/docs.html
+++ b/html/docs.html
@@ -8,7 +8,7 @@
 
 <link rel="icon" href="static/img/mlpack-logo.svg" type="image/gif">
 
-<title>mlpack - Docummentation</title>
+<title>mlpack - Documentation</title>
 </head>
 
 <body>


### PR DESCRIPTION
The title of the documentation page was "docummentation". I changed it to "documentation".